### PR TITLE
Restaura rota antiga para vinculo de pais/alunos

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,4 +1,5 @@
 class StudentsController < ApplicationController
+  skip_before_action :authenticate_user!, only: :search_api
 
   def index
     return render json: nil if params[:classroom_id].blank?
@@ -36,6 +37,18 @@ class StudentsController < ApplicationController
     students = StudentDecorator.data_for_select2_remote(params[:description])
 
     render json: students
+  end
+
+
+  def search_api
+    begin
+      api = IeducarApi::Students.new(configuration.to_api)
+      result = api.fetch_by_cpf(params[:document], params[:student_code])
+
+      render json: result["alunos"].to_json
+    rescue IeducarApi::Base::ApiError => e
+      render json: e.message, status: "404"
+    end
   end
 
   def search_autocomplete

--- a/app/services/ieducar_api/students.rb
+++ b/app/services/ieducar_api/students.rb
@@ -16,5 +16,23 @@ module IeducarApi
         aluno_id: student_code
       )
     end
+
+    def fetch_registereds(params = {})
+      params[:resource] = 'alunos-matriculados'
+
+      raise ApiError, 'É necessário informar a escola: unity_code' if params[:unity_api_code].blank?
+      raise ApiError, 'É necessário informar o ano: year' if params[:year].blank?
+      raise ApiError, 'É necessário informar a data: date' if params[:date].blank?
+
+      params['escola_id'] = params.delete(:unity_api_code)
+      params['ano'] = params.delete(:year)
+      params['data'] = params.delete(:date)
+      params['curso_id'] = params.delete(:course_api_code)
+      params['serie_id'] = params.delete(:grade_api_code)
+      params['turma_id'] = params.delete(:classroom_api_code)
+      params['turno_id'] = params.delete(:period)
+
+      fetch(params)
+    end
   end
 end

--- a/config/locales/routes.yml
+++ b/config/locales/routes.yml
@@ -90,6 +90,7 @@ pt-BR:
     cancel: 'cancelar'
     parents: 'pais'
     employees: 'servidores'
+    search_api: 'api'
     history: 'historico'
     confirm: "confirmar"
     preview: "pre-visualizar"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
     resources :students do
       collection do
         get :recovery_lowest_note
+        get :search_api
         get :in_recovery
         get :select2_remote
         get :search_autocomplete


### PR DESCRIPTION
- Ajustada a tela de `/registro`

A tela após aplicar estes ajustes deve funcionar corretamente, antes estava dando um 404:

![WhatsApp Image 2024-02-26 at 08 10 51](https://github.com/Loginxtech/i-diario-fork/assets/52477784/c769f010-da57-4efb-a360-61a40a00e405)

Após ajustes (Requisição funcionando corretamente, retornado a mensagem de erro da consulta):

![Captura de tela de 2024-03-19 20-08-24](https://github.com/Loginxtech/i-diario-fork/assets/52477784/a79757d4-57b7-455d-abb1-77a340d7c349)




